### PR TITLE
refactor: stop using undefined

### DIFF
--- a/app/types/taskBasicInfo.ts
+++ b/app/types/taskBasicInfo.ts
@@ -13,10 +13,10 @@ export interface TaskBasicInfo extends TaskTableItem {
     wakes: bigint;
     wakerClones: bigint;
     wakerDrops: bigint;
-    lastWake?: Timestamp;
+    lastWake: Timestamp | null;
     selfWakes: bigint;
     wakerCount: bigint;
-    lastWokenDuration?: DurationWithStyle;
+    lastWokenDuration: DurationWithStyle | null;
 }
 
 export function toTaskBasicInfo(
@@ -45,7 +45,7 @@ export function toTaskBasicInfo(
         wakerCount: task.wakerCount(),
         lastWokenDuration: sinceWakeDuration
             ? getDurationWithClass(sinceWakeDuration)
-            : undefined,
+            : null,
     };
 }
 

--- a/app/types/taskTableItem.ts
+++ b/app/types/taskTableItem.ts
@@ -18,9 +18,8 @@ export interface TaskTableItem {
     pools: bigint;
     kind: string;
     location: string;
-    // TODO: format fields.
     fields: Array<Field>;
-    class?: string;
+    class: string | null;
 }
 
 export function toTaskTableItem(
@@ -43,7 +42,7 @@ export function toTaskTableItem(
         class:
             task.state() === TaskState.Completed
                 ? "bg-slate-50 dark:bg-slate-950 animate-pulse"
-                : undefined,
+                : null,
     };
 }
 


### PR DESCRIPTION
Javascript is so hard. Perhaps I'm misusing undefined in these interfaces. We could always use null to explicitly show that it has no value.