### PR TITLE
fix: calculate percentage correctly

### DIFF
--- a/app/tests/unit/duration.test.ts
+++ b/app/tests/unit/duration.test.ts
@@ -24,8 +24,8 @@ describe("Duration", () => {
     });
 
     test("asSeconds", () => {
-        const duration = new Duration(1n, 0);
-        expect(duration.asSeconds()).toEqual(1);
+        const duration = new Duration(1n, 1e9);
+        expect(duration.asSeconds()).toEqual(2);
     });
 
     test("asMilliseconds", () => {

--- a/app/types/common/duration.ts
+++ b/app/types/common/duration.ts
@@ -43,7 +43,7 @@ export class Duration {
     }
 
     asSeconds(): number {
-        return Number(this.seconds);
+        return Number(this.seconds) + this.nanos / 1e9;
     }
 
     asMilliseconds(): number {

--- a/app/types/task/tokioTask.ts
+++ b/app/types/task/tokioTask.ts
@@ -65,8 +65,11 @@ export class TokioTask {
     }
 
     busyDuration(since: Timestamp): Duration {
-        if (this.stats.lastPollStarted && this.stats.lastPollEnded) {
-            if (this.stats.lastPollStarted > this.stats.lastPollEnded) {
+        if (this.stats.lastPollStarted) {
+            if (
+                !this.stats.lastPollEnded ||
+                this.stats.lastPollStarted > this.stats.lastPollEnded
+            ) {
                 // In this case the task is being polled at the moment.
                 const currentTimeInPollDuration = since.subtract(
                     this.stats.lastPollStarted,
@@ -78,8 +81,11 @@ export class TokioTask {
     }
 
     scheduledDuration(since: Timestamp): Duration {
-        if (this.stats.lastWake && this.stats.lastPollStarted) {
-            if (this.stats.lastWake > this.stats.lastPollStarted) {
+        if (this.stats.lastWake) {
+            if (
+                !this.stats.lastPollStarted ||
+                this.stats.lastWake > this.stats.lastPollStarted
+            ) {
                 // In this case the task is scheduled, but has not yet been polled.
                 const currentTimeSinceWakeDuration = since.subtract(
                     this.stats.lastWake,
@@ -161,8 +167,8 @@ export class TokioTask {
     }
 
     durationPercent(now: Timestamp, amt: Duration): number {
-        let percent =
-            (amt.asSeconds() / this.totalDuration(now).asSeconds()) * 100;
+        const total = this.totalDuration(now);
+        let percent = (amt.asSeconds() / total.asSeconds()) * 100;
         if (percent > 100) {
             percent = 100;
         }


### PR DESCRIPTION
1. https://github.com/tokio-rs/console/blob/b158b05df583348c19029c17924b9c898a9e74ef/tokio-console/src/view/task.rs#L173
Because as_secs_f64 also considers Nanos, we need to align this behavior.
2. https://github.com/tokio-rs/console/blob/b158b05df583348c19029c17924b9c898a9e74ef/tokio-console/src/state/tasks.rs#L393
Here we compare two options, we don't check the `last_poll_ended` because None < Some(x). So we need to align this behavior as well.

<img width="1878" alt="image" src="https://github.com/hi-rustin/tokio-console-web/assets/29879298/03658a66-a4d6-4350-86ba-088cc267ad46">

