### PR TITLE
fix: use `.cargo` instead of `cargo` to format location

### DIFF
--- a/app/tests/unit/field.test.ts
+++ b/app/tests/unit/field.test.ts
@@ -94,15 +94,19 @@ describe("formatLocation", () => {
         });
     });
 
-    test("should truncate the registry path when file contains a registry path", () => {
-        const loc = { file: "some/path/cargo/registry/src/some-registry/" };
-        expect(formatLocation(new Location(loc))).toBe("<cargo>/");
-    });
-
     test("should truncate the git checkout path when file contains a git checkout path", () => {
-        const loc = { file: "some/path/cargo/git/checkouts/some-checkout/" };
+        const loc = { file: "some/path/.cargo/git/checkouts/some-checkout/" };
         expect(formatLocation(new Location(loc))).toBe(
             "<cargo>/some-checkout/",
+        );
+    });
+
+    test("should truncate the registry path when file contains a specific registry path", () => {
+        const loc = {
+            file: "/Users/hi-rustin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.25.3/src/runtime/blocking/shutdown.rs:22:20",
+        };
+        expect(formatLocation(new Location(loc))).toBe(
+            "<cargo>/tokio-1.25.3/src/runtime/blocking/shutdown.rs:22:20",
         );
     });
 });

--- a/app/types/common/field.ts
+++ b/app/types/common/field.ts
@@ -4,12 +4,12 @@ import type { Location } from "~/gen/common_pb";
 
 /**
  * Truncate the registry path.
- * If the path contains "/.cargo/registry/src/" or "/git/checkouts/", replace it with "<cargo>/".
+ * If the path contains ".cargo/registry/src/" or ".cargo/git/checkouts/", replace it with "<cargo>/".
  * @param s - The path to truncate.
  * @returns The truncated string.
  */
 export function truncateRegistryPath(s: string): string {
-    const regex = /.*\/cargo(\/registry\/src\/[^/]*\/|\/git\/checkouts\/)/;
+    const regex = /.*\/\.cargo(\/registry\/src\/[^/]*\/|\/git\/checkouts\/)/;
     return s.replace(regex, "<cargo>/");
 }
 


### PR DESCRIPTION
<img width="1640" alt="image" src="https://github.com/hi-rustin/tokio-console-web/assets/29879298/1bd07d8a-10c3-4c55-becd-0b40cf642738">
