### PR TITLE
chore: make renovate can bump pnpm together

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ on:
       - "**[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
+env:
+  # renovate: datasource=npm depName=pnpm
+  PNPM_VERSION: 9.4.0
+
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do
   plan:
@@ -115,7 +119,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         with:
-          version: 9.1.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   # renovate: datasource=npm depName=pnpm
-  PNPM_VERSION: 9.4.0
+  PNPM_VERSION: 9.1.0
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
 
 name: Unit Tests
 
+env:
+  # renovate: datasource=npm depName=pnpm
+  PNPM_VERSION: 9.4.0
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -27,7 +31,7 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         with:
-          version: 9.1.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ name: Unit Tests
 
 env:
   # renovate: datasource=npm depName=pnpm
-  PNPM_VERSION: 9.4.0
+  PNPM_VERSION: 9.1.0
 
 jobs:
   test:


### PR DESCRIPTION
ref https://github.com/hi-rustin/tokio-console-web/pull/224

We should make renovate can also bump pnpm version from CI files.